### PR TITLE
Add method for attempting dynamical region fetching for AWSSystemsManagerParameterStoreBackend

### DIFF
--- a/odd-collector-sdk/odd_collector_sdk/secrets/aws/ssm_parameter_store.py
+++ b/odd-collector-sdk/odd_collector_sdk/secrets/aws/ssm_parameter_store.py
@@ -1,3 +1,5 @@
+import os
+
 import boto3
 import requests
 from odd_collector_sdk.logger import logger
@@ -16,8 +18,12 @@ class AWSSystemsManagerParameterStoreBackend(BaseSecretsBackend):
         collector_plugins_prefix = kwargs.get(
             "collector_plugins_prefix", "/odd/collector_config/plugins"
         )
+        aws_region = kwargs.get("region_name")
 
-        self._region_name = self._dynamically_get_aws_region(kwargs.get("region_name"))
+        self._region_name = os.getenv(
+            "AWS_REGION",
+            self._dynamically_get_aws_region(aws_region),
+        )
         self._collector_settings_parameter_name = self._ensure_leading_slash(
             collector_settings_parameter_name
         )

--- a/odd-collector-sdk/odd_collector_sdk/secrets/aws/ssm_parameter_store.py
+++ b/odd-collector-sdk/odd_collector_sdk/secrets/aws/ssm_parameter_store.py
@@ -13,11 +13,11 @@ class AWSSystemsManagerParameterStoreBackend(BaseSecretsBackend):
             "collector_settings_parameter_name",
             "/odd/collector_config/collector_settings",
         )
-        collector_plugins_prefix = self._dynamically_get_aws_region(
-            kwargs.get("collector_plugins_prefix", "/odd/collector_config/plugins")
+        collector_plugins_prefix = kwargs.get(
+            "collector_plugins_prefix", "/odd/collector_config/plugins"
         )
 
-        self._region_name = kwargs.get("region_name")
+        self._region_name = self._dynamically_get_aws_region(kwargs.get("region_name"))
         self._collector_settings_parameter_name = self._ensure_leading_slash(
             collector_settings_parameter_name
         )
@@ -43,20 +43,19 @@ class AWSSystemsManagerParameterStoreBackend(BaseSecretsBackend):
                 # Token is required for IMDSv2
                 token_response = requests.put(
                     "http://169.254.169.254/latest/api/token",
-                    headers={"X-aws-ec2-metadata-token-ttl-seconds": "21600"}
+                    headers={"X-aws-ec2-metadata-token-ttl-seconds": "21600"},
                 )
                 token = token_response.text
 
                 # Fetch the region
                 region_response = requests.get(
                     "http://169.254.169.254/latest/meta-data/placement/region",
-                    headers={"X-aws-ec2-metadata-token": token}
+                    headers={"X-aws-ec2-metadata-token": token},
                 )
                 return region_response.text
             except requests.RequestException as e:
-                logger.debug(f"Failed to fetch AWS region dynamically: {e}")
+                logger.debug(f"Failed to fetch AWS region dynamically from IMDS: {e}")
         return check_region_argument
-
 
     @staticmethod
     def _ensure_leading_slash(secret_name: str) -> str:

--- a/odd-collector-sdk/odd_collector_sdk/secrets/aws/ssm_parameter_store.py
+++ b/odd-collector-sdk/odd_collector_sdk/secrets/aws/ssm_parameter_store.py
@@ -1,4 +1,5 @@
 import boto3
+import requests
 from odd_collector_sdk.logger import logger
 from odd_collector_sdk.secrets.base_secrets import BaseSecretsBackend
 from yaml import safe_load
@@ -12,8 +13,8 @@ class AWSSystemsManagerParameterStoreBackend(BaseSecretsBackend):
             "collector_settings_parameter_name",
             "/odd/collector_config/collector_settings",
         )
-        collector_plugins_prefix = kwargs.get(
-            "collector_plugins_prefix", "/odd/collector_config/plugins"
+        collector_plugins_prefix = self._dynamically_get_aws_region(
+            kwargs.get("collector_plugins_prefix", "/odd/collector_config/plugins")
         )
 
         self._region_name = kwargs.get("region_name")
@@ -24,6 +25,38 @@ class AWSSystemsManagerParameterStoreBackend(BaseSecretsBackend):
             collector_plugins_prefix
         )
         self._ssm_client = boto3.client("ssm", region_name=self._region_name)
+
+    @staticmethod
+    def _dynamically_get_aws_region(check_region_argument: str) -> str:
+        """
+        This method attempts to fetch the AWS region using the Instance Metadata Service (IMDS)
+        if the region is not explicitly provided.
+
+        Parameters:
+            check_region_argument: the explicitly provided region or None if not provided.
+
+        Returns:
+            The AWS region, either fetched dynamically or from the provided argument.
+        """
+        if check_region_argument is None:
+            try:
+                # Token is required for IMDSv2
+                token_response = requests.put(
+                    "http://169.254.169.254/latest/api/token",
+                    headers={"X-aws-ec2-metadata-token-ttl-seconds": "21600"}
+                )
+                token = token_response.text
+
+                # Fetch the region
+                region_response = requests.get(
+                    "http://169.254.169.254/latest/meta-data/placement/region",
+                    headers={"X-aws-ec2-metadata-token": token}
+                )
+                return region_response.text
+            except requests.RequestException as e:
+                logger.debug(f"Failed to fetch AWS region dynamically: {e}")
+        return check_region_argument
+
 
     @staticmethod
     def _ensure_leading_slash(secret_name: str) -> str:


### PR DESCRIPTION
Adds 2 additional methods to retrieve was region for AWSSystemsManagerParameterStoreBackend.
Prioritisation of getting region:
1) We try to get it from environment variables
2) If there are no such variable we try to get it from collector_config.yaml
3) If config does not contains information about region too we are trying to get it from AWS Instance Metadata Service (we assume ODD deployed to EKS)

If none of this worked - we put None, and get error as we can not setup boto3 connection.