### PR TITLE
Fix sending schema changes in scheduled run

### DIFF
--- a/odd-collector/odd_collector/adapters/postgresql/mappers/relationships/cardinality_checker.py
+++ b/odd-collector/odd_collector/adapters/postgresql/mappers/relationships/cardinality_checker.py
@@ -1,4 +1,3 @@
-from functools import cached_property
 from itertools import chain
 
 from odd_collector.adapters.postgresql.models import UniqueConstraint
@@ -24,7 +23,7 @@ class CardinalityChecker:
 
         return CardinalityType.ONE_TO_ZERO_ONE_OR_MORE
 
-    @cached_property
+    @property
     def _is_ref_to_unique(self) -> bool:
         """
         Check if the source table foreign key refers to unique constraint

--- a/odd-collector/odd_collector/adapters/postgresql/mappers/relationships/relationship_mapper.py
+++ b/odd-collector/odd_collector/adapters/postgresql/mappers/relationships/relationship_mapper.py
@@ -1,5 +1,3 @@
-from functools import cached_property
-
 from odd_collector.adapters.postgresql.mappers.relationships.cardinality_checker import (
     CardinalityChecker,
 )
@@ -51,7 +49,7 @@ class RelationshipMapper:
             data_relationship=self._build_relationship(),
         )
 
-    @cached_property
+    @property
     def _ref_fk_field_list(self):
         return [
             fl
@@ -59,17 +57,17 @@ class RelationshipMapper:
             if fl.name in self.fk_cons.referenced_foreign_key
         ]
 
-    @cached_property
+    @property
     def _fk_field_list(self):
         return [
             fl for fl in self._source_field_list if fl.name in self.fk_cons.foreign_key
         ]
 
-    @cached_property
+    @property
     def _target_field_list(self):
         return self.target.dataset.field_list
 
-    @cached_property
+    @property
     def _source_field_list(self):
         return self.source.dataset.field_list
 

--- a/odd-collector/odd_collector/adapters/snowflake/mappers/relationships/cardinality_checker.py
+++ b/odd-collector/odd_collector/adapters/snowflake/mappers/relationships/cardinality_checker.py
@@ -1,4 +1,3 @@
-from functools import cached_property
 from itertools import chain
 
 from odd_collector.adapters.postgresql.models import UniqueConstraint
@@ -24,7 +23,7 @@ class CardinalityChecker:
 
         return CardinalityType.ONE_TO_ZERO_ONE_OR_MORE
 
-    @cached_property
+    @property
     def _is_ref_to_unique(self) -> bool:
         """
         Check if the source table foreign key refers to unique constraint

--- a/odd-collector/odd_collector/adapters/snowflake/mappers/relationships/relationship_mapper.py
+++ b/odd-collector/odd_collector/adapters/snowflake/mappers/relationships/relationship_mapper.py
@@ -1,5 +1,3 @@
-from functools import cached_property
-
 from odd_collector.adapters.snowflake.domain import (
     ForeignKeyConstraint,
     UniqueConstraint,
@@ -51,7 +49,7 @@ class RelationshipMapper:
             data_relationship=self._build_relationship(),
         )
 
-    @cached_property
+    @property
     def _ref_fk_field_list(self):
         return [
             fl
@@ -59,17 +57,17 @@ class RelationshipMapper:
             if fl.name in self.fk_cons.referenced_foreign_key
         ]
 
-    @cached_property
+    @property
     def _fk_field_list(self):
         return [
             fl for fl in self._source_field_list if fl.name in self.fk_cons.foreign_key
         ]
 
-    @cached_property
+    @property
     def _target_field_list(self):
         return self.target.dataset.field_list
 
-    @cached_property
+    @property
     def _source_field_list(self):
         return self.source.dataset.field_list
 

--- a/odd-collector/poetry.lock
+++ b/odd-collector/poetry.lock
@@ -351,6 +351,17 @@ moreorless = ">=0.2.0"
 volatile = "*"
 
 [[package]]
+name = "cachetools"
+version = "5.3.3"
+description = "Extensible memoizing collections and decorators"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "cachetools-5.3.3-py3-none-any.whl", hash = "sha256:0abad1021d3f8325b2fc1d2e9c8b9c9d57b04c3932657a72465447332c24d945"},
+    {file = "cachetools-5.3.3.tar.gz", hash = "sha256:ba29e2dfa0b8b556606f097407ed1aa62080ee108ab0dc5ec9d6a723a007d105"},
+]
+
+[[package]]
 name = "cassandra-driver"
 version = "3.25.0"
 description = "DataStax Driver for Apache Cassandra"
@@ -5715,4 +5726,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "517bbc479f336abe5d27a2139c43dae2de9942d27c73d262666b31818ae2b222"
+content-hash = "619cbcc06cece1c3e1cf44232650de2a6661b38dd686efe478433b8fa671875c"

--- a/odd-collector/pyproject.toml
+++ b/odd-collector/pyproject.toml
@@ -59,6 +59,7 @@ aioresponses = "^0.7.6"
 pandas = "2.1.0"
 pyarrow = "15.0.0"
 botocore = "^1.34.91"
+cachetools = "^5.3.3"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.1.1"


### PR DESCRIPTION
The problem was not only in @cached_property, but also with `self._metadata = self._get_database_metadata()` so we init self._metadata in the first run, and on the next runs we are only reusing this attribute (as we are not creating new instances of Adapter).