### PR TITLE
resolved AttributeError in Databricks collector (#80)

### DIFF
--- a/odd-collector/odd_collector/adapters/databricks/mappers/models.py
+++ b/odd-collector/odd_collector/adapters/databricks/mappers/models.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, InitVar
 from typing import Any, Optional
 
 from odd_collector.models import Column, Table
@@ -12,4 +12,7 @@ class DatabricksColumn(Column):
 @dataclass()
 class DatabricksTable(Table):
     columns: Optional[list[DatabricksColumn]] = field(default_factory=list)
-    odd_metadata: Optional[dict[str, Any]] = field(default_factory=dict)
+    odd_metadata_init: InitVar[Optional[dict[str, Any]]] = None
+
+    def __post_init__(self, odd_metadata_init):
+        self.metadata = odd_metadata_init

--- a/odd-collector/odd_collector/adapters/databricks/mappers/table.py
+++ b/odd-collector/odd_collector/adapters/databricks/mappers/table.py
@@ -19,7 +19,7 @@ def get_table(raw: dict) -> DatabricksTable:
         type=raw.get("table_type"),
         create_time=datetime_from_milliseconds(raw.get("created_at")),
         update_time=datetime_from_milliseconds(raw.get("updated_at")),
-        odd_metadata=raw,
+        odd_metadata_init=raw,
         columns=[column for column in columns],
     )
     return table


### PR DESCRIPTION
Changed the attribute 'odd_metadata' in the Databricks adapter to InitVar 'odd_metadata_init' for better data initialization. Also updated the respective mapper's field to have the new name and modified the post-initialization method in the model class to assign this data to the metadata attribute.