### PR TITLE
[Airbyte adapter] Improvements for api module

### DIFF
--- a/odd-collector/odd_collector/adapters/airbyte/api.py
+++ b/odd-collector/odd_collector/adapters/airbyte/api.py
@@ -5,6 +5,8 @@ from odd_models.models import DataEntityType
 
 from .logger import logger
 
+SSL_PORT = '443'
+
 
 class AirbyteApi:
     """
@@ -12,7 +14,8 @@ class AirbyteApi:
     """
 
     def __init__(self, host: str, port: str, user: str, password: str) -> None:
-        self.__base_url = f"http://{host}:{port}"
+        protocol = 'https' if port == SSL_PORT else 'http'
+        self.__base_url = f"{protocol}://{host}:{port}"
         self.__auth = aiohttp.BasicAuth(login=user, password=password)
 
     async def get_workspaces(self) -> List[str]:

--- a/odd-collector/odd_collector/adapters/airbyte/api.py
+++ b/odd-collector/odd_collector/adapters/airbyte/api.py
@@ -65,14 +65,16 @@ class OddPlatformApi:
     Class intended to retrieve data from ODD Platform API
     """
 
-    def __init__(self, host_url: str) -> None:
+    def __init__(self, host_url: str, api_auth_key: str = None) -> None:
         self.__base_url = host_url
+        self.__api_auth_key = api_auth_key
 
     async def get_data_entities_oddrns(self, deg_oddrn: str) -> List[Optional[str]]:
         url = "/ingestion/entities/degs/children"
         params = {"oddrn": deg_oddrn}
+        auth_headers = None if self.__api_auth_key is None else {"X-API-Key": self.__api_auth_key}
         entities = []
-        async with aiohttp.ClientSession(self.__base_url) as session:
+        async with aiohttp.ClientSession(self.__base_url, headers=auth_headers) as session:
             try:
                 async with session.get(url, params=params) as resp:
                     result = await resp.json()


### PR DESCRIPTION
- Avoid hardcoding URL protocol to `http` when SSL port specified,  set protocol to https if ssl port detected
- Allow for optional api key for ODD Platform API authentication